### PR TITLE
Ensure workspace root is a private unnamed package

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -42,5 +42,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
       - name: Run Tests
+        run: pnpm test:ember-compat:one ${{ matrix.try-scenario }}
         working-directory: test-app
-        run: pnpm ember try:one ${{ matrix.try-scenario }}

--- a/.release-plan.json
+++ b/.release-plan.json
@@ -14,7 +14,7 @@
           "reason": "Appears in changelog section :bug: Bug Fix"
         }
       ],
-      "pkgJSONPath": "./package.json"
+      "pkgJSONPath": "./ember-set-helper/package.json"
     }
   },
   "description": "## Release (2024-02-08)\n\nember-set-helper 3.0.0 (major)\n\n#### :boom: Breaking Change\n* `ember-set-helper`, `test-app`\n  * [#51](https://github.com/adopted-ember-addons/ember-set-helper/pull/51) Convert to v2 addon, plain function with types ([@johanrd](https://github.com/johanrd))\n\n#### :bug: Bug Fix\n* `ember-set-helper`\n  * [#55](https://github.com/adopted-ember-addons/ember-set-helper/pull/55) Add template-registry.ts ([@johanrd](https://github.com/johanrd))\n\n#### :house: Internal\n* Other\n  * [#61](https://github.com/adopted-ember-addons/ember-set-helper/pull/61) moving to release-plan ([@MelSumner](https://github.com/MelSumner))\n  * [#54](https://github.com/adopted-ember-addons/ember-set-helper/pull/54) Create dependabot.yml ([@MelSumner](https://github.com/MelSumner))\n* `test-app`\n  * [#53](https://github.com/adopted-ember-addons/ember-set-helper/pull/53) Add a little CI ([@MelSumner](https://github.com/MelSumner))\n\n#### Committers: 2\n- Melanie Sumner ([@MelSumner](https://github.com/MelSumner))\n- [@johanrd](https://github.com/johanrd)\n"

--- a/ember-set-helper/package.json
+++ b/ember-set-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-set-helper",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "A better `mut` helper!",
   "keywords": [
     "ember-addon"
@@ -46,7 +46,8 @@
     "start": "concurrently 'npm:start:*'",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
     "start:types": "glint --declaration --watch",
-    "test": "echo 'A v2 addon does not have tests, run tests in test-app'"
+    "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
+    "prepare": "pnpm build"
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.7",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,6 @@
 {
-  "name": "ember-set-helper",
-  "version": "3.0.0",
-  "description": "A better `mut` helper!",
-  "keywords": [
-    "ember-addon"
-  ],
+  "private": true,
   "repository": "https://github.com/adopted-ember-addons/ember-set-helper",
-  "license": "MIT",
-  "author": "Chris Garrett",
   "scripts": {
     "build": "pnpm --filter ember-set-helper build",
     "lint": "pnpm --filter '*' lint",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -24,7 +24,8 @@
     "start": "ember serve",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
     "test:ember": "ember test",
-    "test:ember-compat": "ember try:each"
+    "test:ember-compat": "ember try:each",
+    "test:ember-compat:one": "ember try:one"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",


### PR DESCRIPTION
Noticed this when investigating the CI failure.

So the base `package.json` was
- named `ember-set-helper` which caused the test app to resolve `ember-set-helper` to the root package instead of the addon package
- being released by release-plan, so the released tarball is of the whole monorepo rather than just the addon package
<img width="816" alt="image" src="https://github.com/adopted-ember-addons/ember-set-helper/assets/36919/34c6d5f1-5ac4-43c7-8cc8-8b3397b7f6b5">



Please label `bugfix`